### PR TITLE
Fix typo in experience entry

### DIFF
--- a/src/app/services/experience.service.ts
+++ b/src/app/services/experience.service.ts
@@ -36,7 +36,7 @@ export class ExperienceService {
     },
     {
       id: 2,
-      name: "Google sollution challenge hackathon",
+      name: "Google solution challenge hackathon",
       subname: "Winner",
       subnameText:[ 
         "Team: Convoy",


### PR DESCRIPTION
## Summary
- fix misspelled word in experience entry

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685947694ebc8328bd8d9c2d52953fa7